### PR TITLE
Fix for incorrectly firing ObjectNotFound Exceptions

### DIFF
--- a/src/Typesense.php
+++ b/src/Typesense.php
@@ -86,11 +86,7 @@ class Typesense
         /**
          * @var $document Document
          */
-        $document = $collectionIndex->getDocuments()[$array['id']] ?? null;
-
-        if ($document === null) {
-            throw new ObjectNotFound();
-        }
+        $document = $collectionIndex->getDocuments()[$array['id']];
 
         try {
             $document->retrieve();
@@ -115,10 +111,7 @@ class Typesense
         /**
          * @var $document Document
          */
-        $document = $collectionIndex->getDocuments()[(string) $modelId] ?? null;
-        if ($document === null) {
-            throw new ObjectNotFound();
-        }
+        $document = $collectionIndex->getDocuments()[(string) $modelId];
         $document->delete();
     }
 
@@ -160,10 +153,7 @@ class Typesense
      */
     public function deleteCollection(string $collectionName): array
     {
-        $index = $this->client->getCollections()->{$collectionName} ?? null;
-        if ($index === null) {
-            throw new ObjectNotFound();
-        }
+        $index = $this->client->getCollections()->{$collectionName};
         return $index->delete();
     }
 


### PR DESCRIPTION
## Change Summary

Fixes #7 

The issue here is that when we use the `??` check, it will check if the object exists in the array.

Because it is array accessible, we need to actually try and read the value for the Document object to be created. Otherwise it will check if it is already loaded (it never is), and it will never check and always return `null`. So it never works.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
