### PR TITLE
Fix deleting

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -60,15 +60,11 @@ class TypesenseEngine extends Engine
      */
     public function delete($models): void
     {
-        $collection = $this->typesense->getCollectionIndex($models->first());
-
-        $ids = $models->map->getScoutKey()->values()->all();
-        $ids = join(', ', $ids);
-
-        $query = [
-            'filter_by' => "{$models->first()->getScoutKeyName()}: [${ids}]",
-        ];
-        $this->typesense->deleteDocuments($collection, $query);
+        foreach ($models as $model) {
+            $collection = $this->typesense->getCollectionIndex($model);
+            
+            $this->typesense->deleteDocument($collection, $model->getScoutKey());
+        }
     }
 
     /**


### PR DESCRIPTION
## Change Summary

As described in #6, the optimisation to delete multiple documents at once doesn't work when we are using Laravel/Scout defaults, of `id` being the key used.

As much as I agree that it is a good optimisation to do if deleting multiple documents, it is more important for the library to work with normal defaults, and then try and optimise it.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
