### PR TITLE
Add possibility of using the whereIns array in filter method

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -57,10 +57,10 @@ class TypesenseEngine extends Engine
      */
     private array $locationOrderBy = [];
 
-	/**
-	 * @var bool
-	 */
-	private bool $exhaustiveSearch = false;
+    /**
+     * @var bool
+     */
+    private bool $exhaustiveSearch = false;
 
     /**
      * TypesenseEngine constructor.
@@ -153,7 +153,7 @@ class TypesenseEngine extends Engine
             'page'                => $page,
             'highlight_start_tag' => $this->startTag,
             'highlight_end_tag'   => $this->endTag,
-			'exhaustive_search'   => $this->exhaustiveSearch,
+            'exhaustive_search'   => $this->exhaustiveSearch,
         ];
 
         if ($this->limitHits > 0) {
@@ -266,7 +266,7 @@ class TypesenseEngine extends Engine
     public function parseFilters(array|string $value, string $key): string
     {
         if (is_array($value)) {
-			return sprintf('%s:=%s', $key, '['. implode(', ', $value).']');
+            return sprintf('%s:=%s', $key, '['. implode(', ', $value).']');
         }
 
         return sprintf('%s:=%s', $key, $value);
@@ -483,19 +483,19 @@ class TypesenseEngine extends Engine
         return $this;
     }
 
-	/**
-	 * Setting this to true will make Typesense consider all variations of prefixes and typo corrections of the words in the query exhaustively.
-	 *
-	 * @param bool $exhaustiveSearch
-	 *
-	 * @return $this
-	 */
-	public function exhaustiveSearch(bool $exhaustiveSearch): static
-	{
-		$this->exhaustiveSearch = $exhaustiveSearch;
+    /**
+     * Setting this to true will make Typesense consider all variations of prefixes and typo corrections of the words in the query exhaustively.
+     *
+     * @param bool $exhaustiveSearch
+     *
+     * @return $this
+     */
+    public function exhaustiveSearch(bool $exhaustiveSearch): static
+    {
+        $this->exhaustiveSearch = $exhaustiveSearch;
 
-		return $this;
-	}
+        return $this;
+    }
 
     /**
      * @param string $name

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -276,7 +276,7 @@ class TypesenseEngine extends Engine
     public function parseWhereFilter(array|string $value, string $key): string
     {
         if (is_array($value)) {
-			return sprintf('%s:%s', $key, implode('', $value));
+            return sprintf('%s:%s', $key, implode('', $value));
         }
 
         return sprintf('%s:=%s', $key, $value);

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -260,7 +260,7 @@ class TypesenseEngine extends Engine
     public function parseFilters(array|string $value, string $key): string
     {
         if (is_array($value)) {
-            return sprintf('%s:%s', $key, implode('', $value));
+			return sprintf('%s:=%s', $key, '['. implode(', ', $value).']');
         }
 
         return sprintf('%s:=%s', $key, $value);

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -276,7 +276,7 @@ class TypesenseEngine extends Engine
     public function parseWhereFilter(array|string $value, string $key): string
     {
         if (is_array($value)) {
-            return sprintf('%s=%s', $key, implode(', ', $value));
+			return sprintf('%s:%s', $key, implode('', $value));
         }
 
         return sprintf('%s:=%s', $key, $value);

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -57,6 +57,11 @@ class TypesenseEngine extends Engine
      */
     private array $locationOrderBy = [];
 
+	/**
+	 * @var bool
+	 */
+	private bool $exhaustiveSearch = false;
+
     /**
      * TypesenseEngine constructor.
      *
@@ -148,6 +153,7 @@ class TypesenseEngine extends Engine
             'page'                => $page,
             'highlight_start_tag' => $this->startTag,
             'highlight_end_tag'   => $this->endTag,
+			'exhaustive_search'   => $this->exhaustiveSearch,
         ];
 
         if ($this->limitHits > 0) {
@@ -476,6 +482,20 @@ class TypesenseEngine extends Engine
 
         return $this;
     }
+
+	/**
+	 * Setting this to true will make Typesense consider all variations of prefixes and typo corrections of the words in the query exhaustively.
+	 *
+	 * @param bool $exhaustiveSearch
+	 *
+	 * @return $this
+	 */
+	public function exhaustiveSearch(bool $exhaustiveSearch): static
+	{
+		$this->exhaustiveSearch = $exhaustiveSearch;
+
+		return $this;
+	}
 
     /**
      * @param string $name

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -246,32 +246,54 @@ class TypesenseEngine extends Engine
      */
     protected function filters(Builder $builder): string
     {
-        return collect(array_merge($builder->wheres, $builder->whereIns))
-          ->map([
-              $this,
-              'parseFilters',
-          ])
-          ->values()
-          ->implode(' && ');
+        $whereFilter = collect($builder->wheres)
+            ->map([
+                $this,
+                'parseWhereFilter',
+            ])
+            ->values()
+            ->implode(' && ');
+
+        $whereInFilter = collect($builder->whereIns)
+            ->map([
+                $this,
+                'parseWhereInFilter',
+            ])
+            ->values()
+            ->implode(' && ');
+
+        return $whereFilter . $whereInFilter;
     }
 
     /**
-     * Parse typesense filters.
+     * Parse typesense where filter.
      *
      * @param array|string $value
      * @param string       $key
      *
      * @return string
      */
-    public function parseFilters(array|string $value, string $key): string
+    public function parseWhereFilter(array|string $value, string $key): string
     {
         if (is_array($value)) {
-            return sprintf('%s:=%s', $key, '['. implode(', ', $value).']');
+            return sprintf('%s=%s', $key, implode(', ', $value));
         }
 
         return sprintf('%s:=%s', $key, $value);
     }
 
+    /**
+     * Parse typesense  whereIn filter.
+     *
+     * @param array  $value
+     * @param string $key
+     *
+     * @return string
+     */
+    public function parseWhereInFilter(array $value, string $key): string
+    {
+        return sprintf('%s:=%s', $key, '['. implode(', ', $value).']');
+    }
 
     /**
      * @param mixed $results

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -240,7 +240,7 @@ class TypesenseEngine extends Engine
      */
     protected function filters(Builder $builder): string
     {
-        return collect($builder->wheres)
+        return collect(array_merge($builder->wheres, $builder->whereIns))
           ->map([
               $this,
               'parseFilters',

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -262,7 +262,7 @@ class TypesenseEngine extends Engine
             ->values()
             ->implode(' && ');
 
-        return $whereFilter . $whereInFilter;
+		return $whereFilter . ' && ' . $whereInFilter;
     }
 
     /**

--- a/src/Mixin/BuilderMixin.php
+++ b/src/Mixin/BuilderMixin.php
@@ -121,18 +121,18 @@ class BuilderMixin
         };
     }
 
-	/**
-	 * @param bool $exhaustiveSearch
-	 *
-	 * @return Closure
-	 */
-	public function exhaustiveSearch(): Closure
-	{
-		return function (bool $exhaustiveSearch) {
-			$this->engine()
-				->exhaustiveSearch($exhaustiveSearch);
+    /**
+     * @param bool $exhaustiveSearch
+     *
+     * @return Closure
+     */
+    public function exhaustiveSearch(): Closure
+    {
+        return function (bool $exhaustiveSearch) {
+            $this->engine()
+                ->exhaustiveSearch($exhaustiveSearch);
 
-			return $this;
-		};
-	}
+            return $this;
+        };
+    }
 }

--- a/src/Mixin/BuilderMixin.php
+++ b/src/Mixin/BuilderMixin.php
@@ -120,4 +120,19 @@ class BuilderMixin
             return $this;
         };
     }
+
+	/**
+	 * @param bool $exhaustiveSearch
+	 *
+	 * @return Closure
+	 */
+	public function exhaustiveSearch(): Closure
+	{
+		return function (bool $exhaustiveSearch) {
+			$this->engine()
+				->exhaustiveSearch($exhaustiveSearch);
+
+			return $this;
+		};
+	}
 }


### PR DESCRIPTION
## Change Summary
- I add here the possibility of using the array whereIns in the filters by merging it with the array wheres.
- I added the `exhaustiveSearch` method to set the option when use the search.

Linked issue: #19 

Below example of how the code works:

<img width="252" alt="Screenshot 2022-04-25 at 10 31 04" src="https://user-images.githubusercontent.com/6703591/165053476-df4e95a2-3f46-4662-a2cb-bf5a63981e0b.png">
<img width="294" alt="Screenshot 2022-04-25 at 10 30 36" src="https://user-images.githubusercontent.com/6703591/165053480-e38c1149-6fbd-4f25-be44-e063927e09a9.png">
<img width="375" alt="Screenshot 2022-04-25 at 10 30 26" src="https://user-images.githubusercontent.com/6703591/165053485-c743b3de-2a44-40e5-bee3-8d161e9cd085.png">

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
