### PR TITLE
Initial Multi search Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,12 +41,12 @@
   "require": {
     "php": "^8.0",
     "laravel/scout": "^8.0|^9.0",
-    "illuminate/bus": "^7.0|^8.0",
-    "illuminate/contracts": "^7.0|^8.0",
-    "illuminate/database": "^7.0|^8.0",
-    "illuminate/pagination": "^7.0|^8.0",
-    "illuminate/queue": "^7.0|^8.0",
-    "illuminate/support": "^7.0|^8.0",
+    "illuminate/bus": "^7.0|^8.0|^9.0",
+    "illuminate/contracts": "^7.0|^8.0|^9.0",
+    "illuminate/database": "^7.0|^8.0|^9.0",
+    "illuminate/pagination": "^7.0|^8.0|^9.0",
+    "illuminate/queue": "^7.0|^8.0|^9.0",
+    "illuminate/support": "^7.0|^8.0|^9.0",
     "typesense/typesense-php": "^4.0"
   },
   "config": {

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -138,6 +138,11 @@ class TypesenseEngine extends Engine
     private array $hiddenHits = [];
 
     /**
+     * @var array
+     */
+    private array $optionsMulti = [];
+
+    /**
      * TypesenseEngine constructor.
      *
      * @param Typesense $typesense
@@ -342,13 +347,18 @@ class TypesenseEngine extends Engine
      */
     protected function performSearch(Builder $builder, array $options = []): mixed
     {
-        $documents = $this->typesense->getCollectionIndex($builder->model)
-                                     ->getDocuments();
-        if ($builder->callback) {
-            return call_user_func($builder->callback, $documents, $builder->query, $options);
-        }
+        if(!$this->optionsMulti)
+        {
+            $documents = $this->typesense->getCollectionIndex($builder->model)
+                ->getDocuments();
+            if ($builder->callback) {
+                return call_user_func($builder->callback, $documents, $builder->query, $options);
+            }
 
-        return $documents->search($options);
+            return $documents->search($options);
+        } else {
+            return $this->typesense->multiSearch(["searches" => $this->optionsMulti], $options);
+        }
     }
 
     /**
@@ -804,6 +814,20 @@ class TypesenseEngine extends Engine
     public function enableOverrides(bool $enableOverrides): static
     {
         $this->enableOverrides = $enableOverrides;
+
+        return $this;
+    }
+
+    /**
+     * If you want to search multi queries in the same call
+     *
+     * @param array $optionsMulti
+     *
+     * @return $this
+     */
+    public function searchMulti(array $optionsMulti): static
+    {
+        $this->optionsMulti = $optionsMulti;
 
         return $this;
     }

--- a/src/Mixin/BuilderMixin.php
+++ b/src/Mixin/BuilderMixin.php
@@ -362,7 +362,7 @@ class BuilderMixin
     }
 
     /**
-     * @param array $builders
+     * @param array $searchRequests
      *
      * @return \Closure
      */

--- a/src/Mixin/BuilderMixin.php
+++ b/src/Mixin/BuilderMixin.php
@@ -360,4 +360,18 @@ class BuilderMixin
             return $this;
         };
     }
+
+    /**
+     * @param array $builders
+     *
+     * @return \Closure
+     */
+    public function searchMulti(): Closure
+    {
+        return function (array $builders) {
+            $this->engine()->searchMulti($builders);
+
+            return $this;
+        };
+    }
 }

--- a/src/Mixin/BuilderMixin.php
+++ b/src/Mixin/BuilderMixin.php
@@ -295,7 +295,7 @@ class BuilderMixin
     {
         return function (bool $exhaustiveSearch) {
             $this->engine()
-                ->setExhaustiveSearch($exhaustiveSearch);
+                ->exhaustiveSearch($exhaustiveSearch);
 
             return $this;
         };

--- a/src/Mixin/BuilderMixin.php
+++ b/src/Mixin/BuilderMixin.php
@@ -120,4 +120,244 @@ class BuilderMixin
             return $this;
         };
     }
+
+    /**
+     * @param array $facetBy
+     *
+     * @return \Closure
+     */
+    public function facetBy(): Closure
+    {
+        return function (array $facetBy) {
+            $this->engine()
+                ->facetBy($facetBy);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param int $maxFacetValues
+     *
+     * @return \Closure
+     */
+    public function setMaxFacetValues(): Closure
+    {
+        return function (int $maxFacetValues) {
+            $this->engine()
+                ->setMaxFacetValues($maxFacetValues);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param string $facetQuery
+     *
+     * @return \Closure
+     */
+    public function facetQuery(): Closure
+    {
+        return function (string $facetQuery) {
+            $this->engine()
+                ->facetQuery($facetQuery);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param array $includeFields
+     *
+     * @return \Closure
+     */
+    public function setIncludeFields(): Closure
+    {
+        return function (array $includeFields) {
+            $this->engine()
+                ->setIncludeFields($includeFields);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param array $excludeFields
+     *
+     * @return \Closure
+     */
+    public function setExcludeFields(): Closure
+    {
+        return function (array $excludeFields) {
+            $this->engine()
+                ->setExcludeFields($excludeFields);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param array $highlightFields
+     *
+     * @return \Closure
+     */
+    public function setHighlightFields(): Closure
+    {
+        return function (array $highlightFields) {
+            $this->engine()
+                ->setHighlightFields($highlightFields);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param array $pinnedHits
+     *
+     * @return \Closure
+     */
+    public function setPinnedHits(): Closure
+    {
+        return function (array $pinnedHits) {
+            $this->engine()
+                ->setPinnedHits($pinnedHits);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param array $hiddenHits
+     *
+     * @return \Closure
+     */
+    public function setHiddenHits(): Closure
+    {
+        return function (array $hiddenHits) {
+            $this->engine()
+                ->setHiddenHits($hiddenHits);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param array $highlightFullFields
+     *
+     * @return \Closure
+     */
+    public function setHighlightFullFields(): Closure
+    {
+        return function (array $highlightFullFields) {
+            $this->engine()
+                ->setHighlightFullFields($highlightFullFields);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param int $highlightAffixNumTokens
+     *
+     * @return \Closure
+     */
+    public function setHighlightAffixNumTokens(): Closure
+    {
+        return function (int $highlightAffixNumTokens) {
+            $this->engine()
+                ->setHighlightAffixNumTokens($highlightAffixNumTokens);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param int $snippetThreshold
+     *
+     * @return \Closure
+     */
+    public function setSnippetThreshold(): Closure
+    {
+        return function (int $snippetThreshold) {
+            $this->engine()
+                ->setSnippetThreshold($snippetThreshold);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param bool $exhaustiveSearch
+     *
+     * @return \Closure
+     */
+    public function setExhaustiveSearch(): Closure
+    {
+        return function (bool $exhaustiveSearch) {
+            $this->engine()
+                ->setExhaustiveSearch($exhaustiveSearch);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param bool $useCache
+     *
+     * @return \Closure
+     */
+    public function setUseCache(): Closure
+    {
+        return function (bool $useCache) {
+            $this->engine()
+                ->setUseCache($useCache);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param int $cacheTtl
+     *
+     * @return \Closure
+     */
+    public function setCacheTtl(): Closure
+    {
+        return function (int $cacheTtl) {
+            $this->engine()
+                ->setCacheTtl($cacheTtl);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param bool $prioritizeExactMatch
+     *
+     * @return \Closure
+     */
+    public function setPrioritizeExactMatch(): Closure
+    {
+        return function (bool $prioritizeExactMatch) {
+            $this->engine()
+                ->setPrioritizeExactMatch($prioritizeExactMatch);
+
+            return $this;
+        };
+    }
+
+    /**
+     * @param bool $enableOverrides
+     *
+     * @return \Closure
+     */
+    public function enableOverrides(): Closure
+    {
+        return function (bool $enableOverrides) {
+            $this->engine()
+                ->enableOverrides($enableOverrides);
+
+            return $this;
+        };
+    }
 }

--- a/src/Mixin/BuilderMixin.php
+++ b/src/Mixin/BuilderMixin.php
@@ -368,8 +368,8 @@ class BuilderMixin
      */
     public function searchMulti(): Closure
     {
-        return function (array $builders) {
-            $this->engine()->searchMulti($builders);
+        return function (array $searchRequests) {
+            $this->engine()->searchMulti($searchRequests);
 
             return $this;
         };

--- a/src/Typesense.php
+++ b/src/Typesense.php
@@ -185,4 +185,17 @@ class Typesense
         $index = $this->client->getCollections()->{$collectionName};
         return $index->delete();
     }
+
+    /**
+     * @param array $searchRequests
+     * @param array $commonSearchParams
+     *
+     * @return array
+     * @throws \Typesense\Exceptions\TypesenseClientError
+     * @throws \Http\Client\Exception
+     */
+    public function multiSearch(array $searchRequests, array $commonSearchParams): array
+    {
+        return $this->client->multiSearch->perform($searchRequests, $commonSearchParams);
+    }
 }


### PR DESCRIPTION
## Change Summary
I added support to multiple search. #20 
```php
$results = MyModel::search("")
->searchMulti([
    [
        "collection" => "products",
        "q" => "shoe",
    ],
    [
        "collection" => "products",
        "q" => "Nike",
    ],
])
->paginateRaw();
```

Added extra parameters
```php
$search->facetBy(['string']);
$search->setMaxFacetValues(10);
$search->facetQuery('category');
$search->setIncludeFields(['string']);
$search->setExcludeFields(['string']);
$search->setHighlightFields(['string']);
$search->setPinnedHits(['string']);
$search->setHiddenHits(['string']);
$search->setHighlightFullFields(['string']);
$search->setHighlightAffixNumTokens(4);
$search->setSnippetThreshold(60);
$search->exhaustiveSearch(false);
$search->setUseCache(false);
$search->setCacheTtl(60);
$search->setPrioritizeExactMatch(true);
$search->enableOverrides(true);
```
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
