### PR TITLE
Support for Scout shouldBeSearchable

### DIFF
--- a/src/Typesense.php
+++ b/src/Typesense.php
@@ -123,9 +123,14 @@ class Typesense
         /**
          * @var $document Document
          */
-        $document = $collectionIndex->getDocuments()[(string) $modelId];
+        $document = $collectionIndex->getDocuments()[(string) $modelId] ?? null;
 
-        return $document->delete();
+        // dd($document);
+        if($document) {
+            return $document->delete();
+        }
+
+        return [];
     }
 
     /**


### PR DESCRIPTION
Scout's `shouldBeSearchable` function fires a delete record on all save/create events. This makes sense as Scout does not keep track if models have been added before or not. 

## Change Summary
<!--- Described your changes here -->
This update checks for the model's existence before attempting to delete it.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
