### PR TITLE
fix: filters function return ' && ' when `wheres` and `whereIns` is e…

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -261,8 +261,10 @@ class TypesenseEngine extends Engine
             ])
             ->values()
             ->implode(' && ');
-
-		return $whereFilter . ' && ' . $whereInFilter;
+	
+	return $whereFilter . (
+            (strlen($whereFilter) > 0 && strlen($whereInFilter) > 0) ? ' && ' : ''
+        ) . $whereInFilter;
     }
 
     /**


### PR DESCRIPTION
## Change Summary

fix: filters function return ' && ' when `wheres` and `whereIns` is empty

typesense v0.24 `/collections/{collectionName}/documents/search` api return error:
> Could not parse the filter query: unbalanced `&&` operands

## PR Checklist

- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
