### PR TITLE
Fix filters function

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -250,19 +250,17 @@ class TypesenseEngine extends Engine
             ->map([
                 $this,
                 'parseWhereFilter',
-            ])
-            ->values()
-            ->implode(' && ');
+            ]);
 
         $whereInFilter = collect($builder->whereIns)
             ->map([
                 $this,
                 'parseWhereInFilter',
-            ])
-            ->values()
-            ->implode(' && ');
+            ]);
 
-		return $whereFilter . ' && ' . $whereInFilter;
+        $combinedFilter = $whereFilter->merge($whereFilter);
+
+		return $combinedFilter->values()->implode(' && ');
     }
 
     /**

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -258,9 +258,9 @@ class TypesenseEngine extends Engine
                 'parseWhereInFilter',
             ]);
 
-        $combinedFilter = $whereFilter->merge($whereFilter);
+        $combinedFilter = $whereFilter->merge($whereInFilter);
 
-		return $combinedFilter->values()->implode(' && ');
+	return $combinedFilter->values()->implode(' && ');
     }
 
     /**


### PR DESCRIPTION
Make filters function much more robust

## Change Summary
the filters function always returns something like && also if there are no wheres or whereIns. Typesense then returns the following error:
![image](https://user-images.githubusercontent.com/5661837/199492463-db8ee2ca-1844-4fbe-b59a-24c0b39ef5b6.png)

Solution:
Join the 2 collections first and implode on return

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
