### PR TITLE
Upgrade illuminate required version for Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,12 +41,12 @@
   "require": {
     "php": "^8.0",
     "laravel/scout": "^8.0|^9.0",
-    "illuminate/bus": "^7.0|^8.0|^9.0",
-    "illuminate/contracts": "^7.0|^8.0|^9.0",
-    "illuminate/database": "^7.0|^8.0|^9.0",
-    "illuminate/pagination": "^7.0|^8.0|^9.0",
-    "illuminate/queue": "^7.0|^8.0|^9.0",
-    "illuminate/support": "^7.0|^8.0|^9.0",
+    "illuminate/bus": "^7.0|^8.0|^9.0|^10.0",
+    "illuminate/contracts": "^7.0|^8.0|^9.0|^10.0",
+    "illuminate/database": "^7.0|^8.0|^9.0|^10.0",
+    "illuminate/pagination": "^7.0|^8.0|^9.0|^10.0",
+    "illuminate/queue": "^7.0|^8.0|^9.0|^10.0",
+    "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
     "typesense/typesense-php": "^4.0"
   },
   "config": {


### PR DESCRIPTION
## Change Summary

- Allow v10 for the Illuminate packages (Allowing Laravel 10 upgrade)

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
