### PR TITLE
Fixes preparation of filters and revert breaking changes

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -403,9 +403,9 @@ class TypesenseEngine extends Engine
             ->values()
             ->implode(' && ');
 
-        return $whereFilter . (
-            ($whereFilter !== '' && $whereInFilter !== '') ? ' && ' : ''
-            ) . $whereInFilter;
+        return collect([$whereFilter, $whereInFilter])
+            ->filter(fn($filter) => $filter !== '')
+            ->implode(' && ');
     }
 
     /**

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -162,18 +162,14 @@ class TypesenseEngine extends Engine
      */
     public function update($models): void
     {
-        $changes = $models->first()->getDirty();
-        $searchableArray = $models->first()->toSearchableArray();
-        if (!empty(array_intersect(array_keys($changes), array_keys($searchableArray)))) {
-            $collection = $this->typesense->getCollectionIndex($models->first());
+        $collection = $this->typesense->getCollectionIndex($models->first());
 
-            if ($this->usesSoftDelete($models->first()) && config('scout.soft_delete', false)) {
-                $models->each->pushSoftDeleteMetadata();
-            }
-
-            $this->typesense->importDocuments($collection, $models->map(fn($m) => $m->toSearchableArray())
-                ->toArray());
+        if ($this->usesSoftDelete($models->first()) && config('scout.soft_delete', false)) {
+            $models->each->pushSoftDeleteMetadata();
         }
+
+        $this->typesense->importDocuments($collection, $models->map(fn($m) => $m->toSearchableArray())
+            ->toArray());
     }
 
     /**


### PR DESCRIPTION
## Change Summary

* Simplify the syntax of the filters preparation for a more readable one and also prevent the case when `$whereFilter` is empty but `$whereInFilter` is filled. This is issue is related to https://github.com/typesense/laravel-scout-typesense-driver/issues/43
* Revert changes that is causing document update breakage. Reported in https://github.com/typesense/laravel-scout-typesense-driver/issues/45. Same PR as https://github.com/typesense/laravel-scout-typesense-driver/pull/47

### Concerning issue #43

It takes care of the following cases :

```
$whereFilter = 'a';
$whereInFilter = 'b';
// Expected 'a && b'

$whereFilter = 'a';
$whereInFilter = '';
// Expected 'a'

$whereFilter = '';
$whereInFilter = 'b';
// Expected 'b'

$whereFilter = '';
$whereInFilter = '';
// Expected ''
```


## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
