### PR TITLE
Allow upgrade of typesense/php-typesense dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "illuminate/pagination": "^7.0|^8.0|^9.0|^10.0",
     "illuminate/queue": "^7.0|^8.0|^9.0|^10.0",
     "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
-    "typesense/typesense-php": "^4.0",
+    "typesense/typesense-php": "*",
     "symfony/http-client": "^5.4"
   },
   "config": {


### PR DESCRIPTION
This change allow to be up to date with typesense main library.

I noticed issue with import due to the version installed, and I wasn't able to move to version 4.8 (4.0 previously in composer.json)

```
Typesense\Documents::import(): Argument #1 ($documents) must be of type string, array given, called in /vendor/typesense/laravel-scout-typesense-driver/src/Typesense.php on line 184
```

After checking, it seems the import method of Documents.php was requiring a string in v4.0 while pushing an array.
This code is accepting arrays in version 4.8

I performed the following test locally
- Flush
- Full Import
- Search (using wherein too)

I'm aware using a * may be an issue if you want to control the dependency lifecycle, I could switch to 4.8 too.

Finally, to be fully compatible with PHP8.2 / Laravel 10, I pushed a PR on typesense to update monolog: https://github.com/typesense/typesense-php/pull/34


## Change Summary

- Set wildcard for the typesense/php-typesense dependency 

## PR Checklist

- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
