### PR TITLE
PHP 8.2 throws deprecation warning on using ${var} in strings.

### DIFF
--- a/src/Typesense.php
+++ b/src/Typesense.php
@@ -192,7 +192,7 @@ class Typesense
         $result = [];
         foreach ($importedDocuments as $importedDocument) {
             if (!$importedDocument['success']) {
-                throw new TypesenseClientError("Error importing document: ${importedDocument['error']}");
+                throw new TypesenseClientError("Error importing document: {$importedDocument['error']}");
             }
 
             $result[] = new TypesenseDocumentIndexResponse($importedDocument['code'] ?? 0, $importedDocument['success'], $importedDocument['error'] ?? null, json_decode($importedDocument['document'] ?? '[]', true, 512, JSON_THROW_ON_ERROR));


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
