### PR TITLE
Align SoftDelete logic with Model::preventAccessingMissingAttributes();

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -168,7 +168,7 @@ class TypesenseEngine extends Engine
             $models->each->pushSoftDeleteMetadata();
         }
 
-        if (is_null($models->first()?->deleted_at)) {
+        if (!$this->usesSoftDelete($models->first()) || is_null($models->first()?->deleted_at)) {
             $this->typesense->importDocuments($collection, $models->map(fn($m) => $m->toSearchableArray())
                 ->toArray());
         }


### PR DESCRIPTION
Hello,
I noticed an issue in commit 4b76635713d45df70a6070513217340724b7c278 where a logic was introduced to handle the `deleted_at` column.

However, in my project, the native Laravel's sanity check was enabled in my `AppServiceProvider` via `Model::preventAccessingMissingAttributes()`, as described in this article: https://planetscale.com/blog/laravels-safety-mechanisms.

As a result, the `TypesenseEngine.php` attempts to access the `deleted_at` property, which may not be present on the model if the `SoftDeletes` trait is not used on model class. 

This results in an `Illuminate\Database\Eloquent\MissingAttributeException` with the following message:
```
The attribute [deleted_at] either does not exist or was not retrieved for model [App\Models\MyTestModel]. {"exception":"[object] (Illuminate\\Database\\Eloquent\\MissingAttributeException(code: 0): The attribute [deleted_at] either does not exist or was not retrieved for model [App\\Models\\MyTestModel]. at /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:478)
```

I have addressed this issue by adding an additional check, which resolved the problem. Please review my pull request.