### PR TITLE
Fix/add prefix param

### DIFF
--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -143,6 +143,11 @@ class TypesenseEngine extends Engine
     private array $optionsMulti = [];
 
     /**
+     * @var string|null
+     */
+    private ?string $prefix;
+
+    /**
      * TypesenseEngine constructor.
      *
      * @param Typesense $typesense
@@ -306,6 +311,10 @@ class TypesenseEngine extends Engine
             }
             $params['sort_by'] .= $this->parseOrderBy($builder->orders);
         }
+        
+        if (!empty($this->prefix)) {
+            $params['prefix'] = $this->prefix;
+        }
 
         return $params;
     }
@@ -403,7 +412,7 @@ class TypesenseEngine extends Engine
 
         return $whereFilter . (
             ($whereFilter !== '' && $whereInFilter !== '') ? ' && ' : ''
-            ) . $whereInFilter;
+        ) . $whereInFilter;
     }
 
     /**
@@ -846,6 +855,25 @@ class TypesenseEngine extends Engine
     public function setPrioritizeExactMatch(bool $prioritizeExactMatch): static
     {
         $this->prioritizeExactMatch = $prioritizeExactMatch;
+
+        return $this;
+    }
+
+    /**
+     * Indicates that the last word in the query should be treated as a prefix, and not as a whole word. 
+     * 
+     * You can also control the behavior of prefix search on a per field basis.
+     * For example, if you are querying 3 fields and want to enable prefix searching only on the first field, use ?prefix=true,false,false. 
+     * The order should match the order of fields in query_by. 
+     * If a single value is specified for prefix the same value is used for all fields specified in query_by.
+     *
+     * @param string $prefix
+     *
+     * @return $this
+     */
+    public function setPrefix(string $prefix): static
+    {
+        $this->prefix = $prefix;
 
         return $this;
     }

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -412,7 +412,7 @@ class TypesenseEngine extends Engine
 
         return $whereFilter . (
             ($whereFilter !== '' && $whereInFilter !== '') ? ' && ' : ''
-        ) . $whereInFilter;
+            ) . $whereInFilter;
     }
 
     /**

--- a/src/Engines/TypesenseEngine.php
+++ b/src/Engines/TypesenseEngine.php
@@ -145,7 +145,7 @@ class TypesenseEngine extends Engine
     /**
      * @var string|null
      */
-    private ?string $prefix;
+    private ?string $prefix = null;
 
     /**
      * TypesenseEngine constructor.

--- a/src/Mixin/BuilderMixin.php
+++ b/src/Mixin/BuilderMixin.php
@@ -347,6 +347,21 @@ class BuilderMixin
     }
 
     /**
+     * @param string $prefix
+     *
+     * @return \Closure
+     */
+    public function setPrefix(): Closure
+    {
+        return function (string $prefix) {
+            $this->engine()
+                ->setPrefix($prefix);
+
+            return $this;
+        };
+    }
+
+    /**
      * @param bool $enableOverrides
      *
      * @return \Closure


### PR DESCRIPTION
## Change Summary
- Added the 'prefix' parameter to the search query options.

I am open to alternative solutions for including this parameter in the search query, such as integrating it as a parameter via search(). However, this addition is essential. Without it, when attempting to use text embedding in searches, the following error is encountered: 'ERROR: Prefix search is not supported for remote embedders. Please set prefix=false as an additional search parameter to disable prefix searching.' This issue severely impedes the usability of this library with text embedding search.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
